### PR TITLE
Add tool to extract links from all Markdown files to be injected as URLs / seeds into the crawl

### DIFF
--- a/extract_links.py
+++ b/extract_links.py
@@ -1,0 +1,64 @@
+import glob
+import logging
+import markdown
+import os
+import re
+
+from bs4 import BeautifulSoup
+
+
+LOGGING_FORMAT = '%(asctime)s %(levelname)s %(name)s: %(message)s'
+LOG_LEVEL = 'INFO'
+logging.basicConfig(level=LOG_LEVEL, format=LOGGING_FORMAT)
+
+
+def get_markdown_clean(path):
+    """Read markdown from file and convert it into a form that the Python Markdown parser is able to parse"""
+    md = open(path, encoding='utf-8').read()
+    # strip trailing instructions and supportive information
+    md = re.sub(r'^(?:## Instructions|Informative links \(in English\)|Additional Information|Scripts|Thank you to these people who have helped create this document):.*', '', md, flags=re.DOTALL|re.MULTILINE)
+    # fix lists
+    md = re.sub(r'^- ', '\n* ', md)
+    # convert bare URLs into links
+    md = re.sub(r' (https?://\S+)(?=\s|$)', r' <\1>', md)
+    return md
+
+
+web_languages_folders = [
+    'living',
+    'constructed',
+    'extinct',
+    'historical'
+]
+
+web_languages_files = []
+
+for folder in web_languages_folders:
+    for path in glob.iglob(os.path.join(folder, '*.md')):
+        if path.endswith('README.md'):
+            # skip READMEs
+            continue
+        web_languages_files.append(path)
+
+logging.info('Extracting links from %d markdown files', len(web_languages_files))
+
+
+total_links = 0
+
+for path in web_languages_files:
+    md = get_markdown_clean(path)
+    html = markdown.markdown(md, stripTopLevelTags=False)
+    soup = None
+    try:
+        soup = BeautifulSoup(html, 'lxml')
+    except Exception as e:
+        logging.error('Error in converted HTML from <%s>: %s', path, e)
+        continue
+    links = [link['href'] for link in soup.find_all('a', href=True)]
+    print('### {} links from {}'.format(len(links), path))
+    total_links += len(links)
+    for link in links:
+        print(link)
+
+
+logging.info('Extracted %d links from %d markdown files', total_links, len(web_languages_files))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+beautifulsoup4
 jinja2
+lxml
 pyarrow


### PR DESCRIPTION
- supports all forms of Markdown links
  - `[anchor](url)`
  - bare URLs (`https://example.com/`)
  - `<url>`
  - HTML: `<a href="url">`
- tries to strip trailing instructions from Markdown before extracting links

```
$> python3 tools/extract_links.py >/tmp/web-languages-links.txt
2025-01-10 12:28:56,960 INFO root: Extracting links from 7916 markdown files
2025-01-10 12:29:01,725 INFO root: Extracted 1043 links from 7916 markdown files

$> grep -A17 '^### .*living/welsh.md' /tmp/web-languages-links.txt 
### 16 links from living/welsh.md
https://www.bbc.com/cymrufyw
https://golwg360.cymru/
http://www.papuraubro.cymru/
https://eisteddfod.cymru/
https://museum.wales/cy/
https://llyfrau.cymru/
https://www.barddas.cymru/
https://cymdeithas.cymru/
https://www.llyw.cymru/
https://hwb.gov.wales/
https://www.plaid.cymru/
https://www.plaidifanc.org/
https://cy.wikipedia.org
https://www.s4c.cymru/clic/
https://www.meithrin.cymru/
https://www.urdd.cymru/
### 0 links from living/lehalurup.md
```