### PR TITLE
Optionally filter extracted links, filter Wikipedia links by default

### DIFF
--- a/extract_links.py
+++ b/extract_links.py
@@ -1,5 +1,19 @@
+"""
+Extract links from "web-languages" Markdown files
+located at https://github.com/commoncrawl/web-languages/
+
+After cloning the web-languages repository, navigate
+into the web-languages directory and execute this script.
+The extracted links are written to stdout, lines starting
+with the # character are to be ignored.
+
+Call with command-line flags -h or --help for additional options.
+"""
+
+import argparse
 import glob
 import logging
+import sys
 import markdown
 import os
 import re
@@ -15,10 +29,13 @@ logging.basicConfig(level=LOG_LEVEL, format=LOGGING_FORMAT)
 
 
 def get_markdown_clean(path):
-    """Read markdown from file and convert it into a form that the Python Markdown parser is able to parse"""
+    """Read Markdown from file and convert it into a form
+    the Python Markdown parser is able to parse"""
     md = open(path, encoding='utf-8').read()
     # strip trailing instructions and supportive information
-    md = re.sub(r'^(?:## Instructions|Informative links \(in English\)|Additional Information|Scripts|Thank you to these people who have helped create this document):.*', '', md, flags=re.DOTALL|re.MULTILINE)
+    md = re.sub(
+        r'^(?:## Instructions|Informative links \(in English\)|Additional Information|Scripts|Thank you to these people who have helped create this document):.*',
+        '', md, flags=re.DOTALL|re.MULTILINE)
     # fix lists
     md = re.sub(r'^- ', '\n* ', md)
     # convert bare URLs into links
@@ -59,10 +76,28 @@ for folder in web_languages_folders:
             continue
         web_languages_files.append(path)
 
+
+arg_parser = argparse.ArgumentParser(description=__doc__)
+arg_parser.add_argument(
+    '--exclude', type=str,
+    default=r'^https?://[a-z0-9.-]+\.wikipedia\.org/',
+    help='exclusion pattern (regular expression on URLs), '
+    'the default excludes links from Wikipedia. '
+    'Excluded links are commented out and marked by `##-`.')
+args = arg_parser.parse_args(sys.argv[1:])
+
+logging.info('Command-line arguments: %s', args)
+exclusion_pattern = None
+if args.exclude:
+    logging.info('Excluding links / URLs matching %s', args.exclude)
+    exclusion_pattern = re.compile(args.exclude)
+
+
 logging.info('Extracting links from %d markdown files', len(web_languages_files))
 
 
 total_links = 0
+total_excluded = 0
 
 for path in web_languages_files:
     md = get_markdown_clean(path)
@@ -73,11 +108,24 @@ for path in web_languages_files:
     except Exception as e:
         logging.error('Error in converted HTML from <%s>: %s', path, e)
         continue
-    links = [link['href'] for link in soup.find_all('a', href=True)]
-    print('### {} links from {}'.format(len(links), path))
-    total_links += len(links)
-    for link in links:
-        print(normalize_url(link))
+    links = list(map(normalize_url,
+                     [link['href'] for link in soup.find_all('a', href=True)]))
+    links_exclusions = list(map(lambda l: exclusion_pattern.search(l), links))
+    n_excluded = len(list(filter(lambda e: e, links_exclusions)))
+    print('### {} links from {}{}'.format(
+        len(links) - n_excluded, path,
+        ' (excluded: {} out of {})'.format(n_excluded, len(links))
+        if n_excluded else ''))
+    total_links += len(links) - n_excluded
+    total_excluded += n_excluded
+    for link, excluded in zip(links, links_exclusions):
+        if excluded:
+            print('##-', link)
+        else:
+            print(link)
 
 
-logging.info('Extracted %d links from %d markdown files', total_links, len(web_languages_files))
+logging.info('Found %d links in %d markdown files.',
+             total_links + total_excluded, len(web_languages_files))
+logging.info('Accepted %d links, %d excluded by pattern.',
+             total_links, total_excluded)


### PR DESCRIPTION
- add option to filter extracted links by regular expression pattern
- exclude Wikipedia links by default
  - although Wikipedia articles are good starting points for a particular language and a Wikipedia may contain significant amounts of content in a specific language, the benefit of Wikipedia URLs for the crawls is limited: only Wikipedia-internal links are followed. External links are consistently marked with the `rel=nofollow` attribute and, consequently, are not followed by the crawler.
- document the link extraction tool