### PR TITLE
Improve dev workflow: use python3 and auto-unzip ISO-639-3 tables in Makefile; update .gitignore and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 __pycache__
+# Ignore the extracted ISO 639-3 code tables directory and its zip archive.
+# These files are likely large data resources not needed in version control.
+iso-639-3_Code_Tables_20240415/
+iso-639-3_Code_Tables_20240415.zip

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ init:
 get-table:
 	# https://iso639-3.sil.org/code_tables/download_tables
 	wget https://iso639-3.sil.org/sites/iso639-3/files/downloads/iso-639-3_Code_Tables_20240415.zip
+	unzip -o iso-639-3_Code_Tables_20240415.zip
 
 combine-wikipedia:
 	cat wikipedia_languages.csv  wikipedia_languages_extra.csv > wikipedia_languages_all.csv
 
 generate:
-	python generate.py
+	python3 generate.py

--- a/README.md
+++ b/README.md
@@ -7,13 +7,42 @@ web-languages dataset.
 
 
 
-## Installing, etc.
+## Install dependencies:
+**Note:** This project requires Python 3.
 
+## Setup
+
+Install dependencies:
+
+```bash
+make init
 ```
-make install
 
+Download and extract ISO-639-3 tables:
+```
+make get-table
 ```
 
+(Optional) Combine Wikipedia language files:
+```
+make combine-wikipedia
+```
+
+Generate language Markdown files:
+```
+make generate
+```
+
+Downloaded data files (e.g., ISO-639-3 tables) are excluded from version control via `.gitignore`.
+
+## Makefile Targets
+
+| Target             | Description                                      |
+|--------------------|--------------------------------------------------|
+| init               | Install Python dependencies                      |
+| get-table          | Download and unzip ISO-639-3 tables              |
+| combine-wikipedia  | Combine Wikipedia language CSVs                  |
+| generate           | Generate Markdown files from data                |
 
 ## License
 


### PR DESCRIPTION
This PR improves the developer workflow by:

- Updating the Makefile to use `python3` for better cross-platform compatibility.
- Adding an unzip step to the `get-table` target, so the ISO-639-3 tables are automatically extracted after download.
- Updating `.gitignore` to exclude the downloaded zip file and extracted data directory.
- Updating the README to reflect the new setup and Makefile targets.

No data files are committed to the repo. These changes make onboarding and reproducibility easier for new contributors.

Let me know if you’d like any adjustments!