### PR TITLE
Sanitize URLs that might lead to None hostname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.idea

--- a/extract_links.py
+++ b/extract_links.py
@@ -35,8 +35,7 @@ def get_markdown_clean(path):
     md = open(path, encoding='utf-8').read()
     # strip trailing instructions and supportive information
     md = re.sub(
-        r'^(?:## Instructions|Informative links \(in English\)|Additional Information'
-        r'|Scripts|Thank you to these people who have helped create this document):.*',
+        r'^(?:## Instructions|Informative links \(in English\)|Additional Information|Scripts|Thank you to these people who have helped create this document):.*',
         '', md, flags=re.DOTALL | re.MULTILINE)
     # fix lists
     md = re.sub(r'^- ', '\n* ', md)

--- a/extract_links.py
+++ b/extract_links.py
@@ -53,7 +53,7 @@ def repair_empty_authority(u):
 
     `u` is the urllib.parse.ParseResult of the malformed URL.
     """
-    if not u.startswith("http"):
+    if not u.scheme.startswith("http"):
         return None
     host, _, rest = u.path.lstrip('/').partition('/')
     if not host:
@@ -160,13 +160,13 @@ for path in web_languages_files:
     links = []
     links_not_parseable = []
     for link in soup.find_all('a', href=True):
-        link_str = link['href'] if 'href' in link else None
-        normalized = normalize_url(link_str)
+        link_str = link.get('href')
+        normalized = normalize_url(link_str) if link_str else None
         if normalized:
             links.append(normalized)
         else:
             # No crawlable host (relative, mailto:, unrecoverable). Drop it.
-            links_not_parseable.append(link['href'])
+            links_not_parseable.append(link_str)
 
     # With exclusions disabled (`--exclude ''`), exclusion_pattern is None,
     # so nothing is excluded.

--- a/extract_links.py
+++ b/extract_links.py
@@ -73,22 +73,25 @@ def normalize_url(url):
     h = u.hostname
     n = u.netloc
     if not h:
-        # Empty authority. Only repair *absolute* URLs: a malformed
-        # `https:///bla.bla.com` carries a scheme and lost its host to the
-        # path, so we can recover it. A relative URL (no scheme, e.g.
-        # `/path/page.html` or `about.html`) has no host to recover and is
-        # not crawlable on its own, so drop it instead of fabricating a bogus
-        # host from its first path segment.
-        if u.scheme not in ('http', 'https'):
+        # Empty authority. Only repair the one specific malformed shape
+        # `http(s):///host...`, where an extra slash pushed the host into
+        # the path. We match that literal prefix rather than just checking
+        # the scheme: `http:foo/bar` and `mailto:me@x` also parse to an
+        # empty authority, but promoting their first path segment to a host
+        # (`http://foo/bar`, `mailto://me@x`) would fabricate a bogus URL.
+        # Relative URLs (`/path`, `about.html`) have no host either. Drop
+        # all of those.
+        if not re.match(r'(?i)^https?:///', url):
             return None
-        # Try to recover the host from the path, then re-normalize. The
-        # repaired URL has a real host, so it can't re-enter this branch.
+        # Recover the host from the path, then re-normalize. The repaired
+        # URL has a real host, so it can't re-enter this branch.
         repaired = repair_empty_authority(u)
         return normalize_url(repaired) if repaired else None
     if not h.isascii():
         n = h.encode('idna').decode('ascii')
         if u.port:
-            n += ':' + u.port
+            # u.port is an int; cast before concatenating onto the host.
+            n += ':' + str(u.port)
     p = u.path
     if u.path == '':
         p = '/'

--- a/extract_links.py
+++ b/extract_links.py
@@ -53,6 +53,8 @@ def repair_empty_authority(u):
 
     `u` is the urllib.parse.ParseResult of the malformed URL.
     """
+    if not u.startswith("http"):
+        return None
     host, _, rest = u.path.lstrip('/').partition('/')
     if not host:
         return None
@@ -67,11 +69,14 @@ def normalize_url(url):
     host to normalize: relative URLs (e.g. `/path/page.html`, `about.html`),
     non-http(s) schemes (e.g. `mailto:`), and empty-authority inputs from
     which no host can be recovered."""
-    if url.isascii() and re.match(r'^https?://[^/]+/', url):
+
+    # Fast path for already-clean http(s) URLs. `[^/@]+` forbids an `@`,
+    # so URLs carrying `user:password@` credentials fall through to the slow
+    # path below, where the authority is rebuilt from the host alone.
+    if url.isascii() and re.match(r'^https?://[^/@]+/', url):
         return url
     u = urlparse(url)
     h = u.hostname
-    n = u.netloc
     if not h:
         # Empty authority. Only repair the one specific malformed shape
         # `http(s):///host...`, where an extra slash pushed the host into
@@ -87,14 +92,18 @@ def normalize_url(url):
         # URL has a real host, so it can't re-enter this branch.
         repaired = repair_empty_authority(u)
         return normalize_url(repaired) if repaired else None
-    if not h.isascii():
-        n = h.encode('idna').decode('ascii')
-        if u.port:
-            # u.port is an int; cast before concatenating onto the host.
-            n += ':' + str(u.port)
-    p = u.path
-    if u.path == '':
-        p = '/'
+    # Only http(s) URLs are crawlable web links; drop any other scheme
+    # (e.g. `ftp:`, or a scheme-less protocol-relative `//host/...`) even
+    # when it carries a host.
+    if not u.scheme.startswith("http"):
+        return None
+    # Rebuild the authority from the host alone, dropping any
+    # `user:password@` credentials. IDN-encode non-ASCII hosts.
+    n = h.encode('idna').decode('ascii') if not h.isascii() else h
+    if u.port:
+        # u.port is an int; cast before concatenating onto the host.
+        n += ':' + str(u.port)
+    p = u.path or '/'
     return urlunparse((u.scheme, n, p, u.params, u.query, ''))
 
 
@@ -151,16 +160,22 @@ for path in web_languages_files:
     links = []
     links_not_parseable = []
     for link in soup.find_all('a', href=True):
-        normalized = normalize_url(link['href'])
+        link_str = link['href'] if 'href' in link else None
+        normalized = normalize_url(link_str)
         if normalized:
             links.append(normalized)
         else:
             # No crawlable host (relative, mailto:, unrecoverable). Drop it.
             links_not_parseable.append(link['href'])
 
-    links_exclusions = list(map(lambda link: exclusion_pattern.search(link), links))
+    # With exclusions disabled (`--exclude ''`), exclusion_pattern is None,
+    # so nothing is excluded.
+    if exclusion_pattern:
+        links_exclusions = [exclusion_pattern.search(link) for link in links]
+    else:
+        links_exclusions = [None] * len(links)
     # Three disjoint buckets, all derived from the same total extracted count.
-    n_pattern_excluded = len(list(filter(lambda e: e, links_exclusions)))
+    n_pattern_excluded = len(list(filter(lambda e_: e_, links_exclusions)))
     n_unparseable = len(links_not_parseable)
     n_accepted = len(links) - n_pattern_excluded
     # Total links extracted from this file: parseable + unparseable. The

--- a/extract_links.py
+++ b/extract_links.py
@@ -98,8 +98,18 @@ def normalize_url(url):
     if not u.scheme.startswith("http"):
         return None
     # Rebuild the authority from the host alone, dropping any
-    # `user:password@` credentials. IDN-encode non-ASCII hosts.
-    n = h.encode('idna').decode('ascii') if not h.isascii() else h
+    # `user:password@` credentials. IDN-encode non-ASCII hosts. The stock
+    # `idna` codec is strict — empty labels, labels over 63 chars, a trailing
+    # dot or underscores can raise UnicodeError — so treat an un-encodable
+    # host as unparseable (return None) rather than letting it crash the whole
+    # extraction, since normalize_url runs outside the loop's try/except.
+    if h.isascii():
+        n = h
+    else:
+        try:
+            n = h.encode('idna').decode('ascii')
+        except UnicodeError:
+            return None
     if u.port:
         # u.port is an int; cast before concatenating onto the host.
         n += ':' + str(u.port)

--- a/extract_links.py
+++ b/extract_links.py
@@ -67,7 +67,14 @@ def normalize_url(url):
     h = u.hostname
     n = u.netloc
     if not h:
-       # Malformed URL with an empty authority, e.g. `https:///bla.bla.com`.
+       # Empty authority. Only repair *absolute* URLs: a malformed
+       # `https:///bla.bla.com` carries a scheme and lost its host to the
+       # path, so we can recover it. A relative URL (no scheme, e.g.
+       # `/path/page.html` or `about.html`) has no host to recover and is
+       # not crawlable on its own, so drop it instead of fabricating a bogus
+       # host from its first path segment.
+       if u.scheme not in ('http', 'https'):
+           return None
        # Try to recover the host from the path, then re-normalize. The
        # repaired URL has a real host, so it can't re-enter this branch.
        repaired = repair_empty_authority(u)
@@ -118,8 +125,9 @@ if args.exclude:
 logging.info('Extracting links from %d markdown files', len(web_languages_files))
 
 
-total_links = 0
-total_excluded = 0
+total_accepted = 0
+total_pattern_excluded = 0
+total_unparseable = 0
 live = defaultdict(int)
 
 for path in web_languages_files:
@@ -142,14 +150,21 @@ for path in web_languages_files:
            links_not_parseable.append(link)
 
     links_exclusions = list(map(lambda l: exclusion_pattern.search(l), links))
-    n_excluded = len(list(filter(lambda e: e, links_exclusions)))
-    n_excluded += len(links_not_parseable)
+    # Three disjoint buckets, all derived from the same total extracted count.
+    n_pattern_excluded = len(list(filter(lambda e: e, links_exclusions)))
+    n_unparseable = len(links_not_parseable)
+    n_accepted = len(links) - n_pattern_excluded
+    # Total links extracted from this file: parseable + unparseable. The
+    # parseable ones split into accepted and pattern-excluded.
+    n_total = len(links) + n_unparseable
+    n_excluded = n_pattern_excluded + n_unparseable
     print('### {} links from {}{}'.format(
-        len(links) - n_excluded, path,
-        ' (excluded: {} out of {})'.format(n_excluded, len(links))
+        n_accepted, path,
+        ' (excluded: {} out of {})'.format(n_excluded, n_total)
         if n_excluded else ''))
-    total_links += len(links) - n_excluded
-    total_excluded += n_excluded
+    total_accepted += n_accepted
+    total_pattern_excluded += n_pattern_excluded
+    total_unparseable += n_unparseable
     for link, excluded in zip(links, links_exclusions):
         if excluded:
             print('##-', link)
@@ -159,8 +174,9 @@ for path in web_languages_files:
 
 
 logging.info('Found %d links in %d markdown files.',
-             total_links + total_excluded, len(web_languages_files))
-logging.info('Accepted %d links, %d excluded by pattern.',
-             total_links, total_excluded)
+             total_accepted + total_pattern_excluded + total_unparseable,
+             len(web_languages_files))
+logging.info('Accepted %d links, %d excluded by pattern, %d unparseable.',
+             total_accepted, total_pattern_excluded, total_unparseable)
 logging.info('%d languages have non-excluded links',
              len(live))

--- a/extract_links.py
+++ b/extract_links.py
@@ -35,13 +35,15 @@ def get_markdown_clean(path):
     md = open(path, encoding='utf-8').read()
     # strip trailing instructions and supportive information
     md = re.sub(
-        r'^(?:## Instructions|Informative links \(in English\)|Additional Information|Scripts|Thank you to these people who have helped create this document):.*',
-        '', md, flags=re.DOTALL|re.MULTILINE)
+        r'^(?:## Instructions|Informative links \(in English\)|Additional Information'
+        r'|Scripts|Thank you to these people who have helped create this document):.*',
+        '', md, flags=re.DOTALL | re.MULTILINE)
     # fix lists
     md = re.sub(r'^- ', '\n* ', md)
     # convert bare URLs into links
     md = re.sub(r' (https?://\S+)(?=\s|$)', r' <\1>', md)
     return md
+
 
 def repair_empty_authority(u):
     """Repair a URL whose authority is empty (e.g. `https:///bla.bla.com`),
@@ -60,25 +62,30 @@ def repair_empty_authority(u):
 
 def normalize_url(url):
     """Normalize URL: encode IDN host, replace empty path by `/`,
-    strip user and password from authority."""
+    strip user and password from authority.
+
+    Return the normalized URL string, or `None` when there is no crawlable
+    host to normalize: relative URLs (e.g. `/path/page.html`, `about.html`),
+    non-http(s) schemes (e.g. `mailto:`), and empty-authority inputs from
+    which no host can be recovered."""
     if url.isascii() and re.match(r'^https?://[^/]+/', url):
         return url
     u = urlparse(url)
     h = u.hostname
     n = u.netloc
     if not h:
-       # Empty authority. Only repair *absolute* URLs: a malformed
-       # `https:///bla.bla.com` carries a scheme and lost its host to the
-       # path, so we can recover it. A relative URL (no scheme, e.g.
-       # `/path/page.html` or `about.html`) has no host to recover and is
-       # not crawlable on its own, so drop it instead of fabricating a bogus
-       # host from its first path segment.
-       if u.scheme not in ('http', 'https'):
-           return None
-       # Try to recover the host from the path, then re-normalize. The
-       # repaired URL has a real host, so it can't re-enter this branch.
-       repaired = repair_empty_authority(u)
-       return normalize_url(repaired) if repaired else None
+        # Empty authority. Only repair *absolute* URLs: a malformed
+        # `https:///bla.bla.com` carries a scheme and lost its host to the
+        # path, so we can recover it. A relative URL (no scheme, e.g.
+        # `/path/page.html` or `about.html`) has no host to recover and is
+        # not crawlable on its own, so drop it instead of fabricating a bogus
+        # host from its first path segment.
+        if u.scheme not in ('http', 'https'):
+            return None
+        # Try to recover the host from the path, then re-normalize. The
+        # repaired URL has a real host, so it can't re-enter this branch.
+        repaired = repair_empty_authority(u)
+        return normalize_url(repaired) if repaired else None
     if not h.isascii():
         n = h.encode('idna').decode('ascii')
         if u.port:
@@ -142,14 +149,14 @@ for path in web_languages_files:
     links = []
     links_not_parseable = []
     for link in soup.find_all('a', href=True):
-       normalized = normalize_url(link['href'])
-       if normalized:
-           links.append(normalized)
-       else:
-           # print(f"##- {link} cannot be normalized. Skipping it!")
-           links_not_parseable.append(link)
+        normalized = normalize_url(link['href'])
+        if normalized:
+            links.append(normalized)
+        else:
+            # No crawlable host (relative, mailto:, unrecoverable). Drop it.
+            links_not_parseable.append(link['href'])
 
-    links_exclusions = list(map(lambda l: exclusion_pattern.search(l), links))
+    links_exclusions = list(map(lambda link: exclusion_pattern.search(link), links))
     # Three disjoint buckets, all derived from the same total extracted count.
     n_pattern_excluded = len(list(filter(lambda e: e, links_exclusions)))
     n_unparseable = len(links_not_parseable)

--- a/extract_links.py
+++ b/extract_links.py
@@ -43,6 +43,21 @@ def get_markdown_clean(path):
     md = re.sub(r' (https?://\S+)(?=\s|$)', r' <\1>', md)
     return md
 
+def repair_empty_authority(u):
+    """Repair a URL whose authority is empty (e.g. `https:///bla.bla.com`),
+    where the host ended up in the path because of one slash too many.
+    Promote the first non-empty path segment to be the host and rebuild
+    the URL. Return a repaired URL string, or None if nothing can be
+    recovered (e.g. `https:///` has no path segment to promote).
+
+    `u` is the urllib.parse.ParseResult of the malformed URL.
+    """
+    host, _, rest = u.path.lstrip('/').partition('/')
+    if not host:
+        return None
+    return urlunparse((u.scheme, host, '/' + rest, u.params, u.query, u.fragment))
+
+
 def normalize_url(url):
     """Normalize URL: encode IDN host, replace empty path by `/`,
     strip user and password from authority."""
@@ -51,6 +66,12 @@ def normalize_url(url):
     u = urlparse(url)
     h = u.hostname
     n = u.netloc
+    if not h:
+       # Malformed URL with an empty authority, e.g. `https:///bla.bla.com`.
+       # Try to recover the host from the path, then re-normalize. The
+       # repaired URL has a real host, so it can't re-enter this branch.
+       repaired = repair_empty_authority(u)
+       return normalize_url(repaired) if repaired else None
     if not h.isascii():
         n = h.encode('idna').decode('ascii')
         if u.port:
@@ -110,10 +131,19 @@ for path in web_languages_files:
     except Exception as e:
         logging.error('Error in converted HTML from <%s>: %s', path, e)
         continue
-    links = list(map(normalize_url,
-                     [link['href'] for link in soup.find_all('a', href=True)]))
+    links = []
+    links_not_parseable = []
+    for link in soup.find_all('a', href=True):
+       normalized = normalize_url(link['href'])
+       if normalized:
+           links.append(normalized)
+       else:
+           # print(f"##- {link} cannot be normalized. Skipping it!")
+           links_not_parseable.append(link)
+
     links_exclusions = list(map(lambda l: exclusion_pattern.search(l), links))
     n_excluded = len(list(filter(lambda e: e, links_exclusions)))
+    n_excluded += len(links_not_parseable)
     print('### {} links from {}{}'.format(
         len(links) - n_excluded, path,
         ' (excluded: {} out of {})'.format(n_excluded, len(links))


### PR DESCRIPTION
This PR attempt to mitigate issue fixed in (the data) in https://github.com/commoncrawl/web-languages/pull/202

This superseed #9. 

Changes: 
1. Add a method for normalize URLs first attempt a quick validation, if the url is broken, it tries to reconstruct it from the host alone
2. Unparseable URLs are not counted, and reported in the final message